### PR TITLE
Escape strings (untested)

### DIFF
--- a/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
+++ b/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
@@ -70,7 +70,7 @@ class CommandMap(private val commandAcceptor: CommandAcceptor, private val defau
                     stringBuilder.append(it)
                     characterEscaped = false
                 }
-            } else if(!characterEscaped) {
+            } else if (!characterEscaped) {
                 if(it == '"') {
                     whitespaceEscaped = !whitespaceEscaped
                 } else if(it == '\\') {

--- a/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
+++ b/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
@@ -59,14 +59,26 @@ class CommandMap(private val commandAcceptor: CommandAcceptor, private val defau
     private fun String.splitArgs(): List<String> {
         val args = mutableListOf<String>()
         val stringBuilder = StringBuilder()
+        var whitespaceEscaped = false
+        var characterEscaped = false
         forEach {
             val whitespace = it.isWhitespace()
-            if (whitespace) {
+            if (whitespace && !whitespaceEscaped) {
                 args.add(stringBuilder.toString())
                 stringBuilder.clear()
-            }
-            if (it == '\n' || !whitespace) {
+                if(it == '\n') {
+                    stringBuilder.append(it)
+                    characterEscaped = false
+                }
+            } else if(!characterEscaped) {
+                if(it == '"') {
+                    whitespaceEscaped = !whitespaceEscaped
+                } else if(it == '\\') {
+                    characterEscaped = true
+                }
+            } else {
                 stringBuilder.append(it)
+                characterEscaped = false
             }
         }
         if (stringBuilder.isNotEmpty())

--- a/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
+++ b/src/main/kotlin/me/shedaniel/linkie/discord/CommandMap.kt
@@ -70,12 +70,10 @@ class CommandMap(private val commandAcceptor: CommandAcceptor, private val defau
                     stringBuilder.append(it)
                     characterEscaped = false
                 }
-            } else if (!characterEscaped) {
-                if(it == '"') {
-                    whitespaceEscaped = !whitespaceEscaped
-                } else if(it == '\\') {
-                    characterEscaped = true
-                }
+            } else if (!characterEscaped && it == '"') {
+                whitespaceEscaped = !whitespaceEscaped
+            } else if (!characterEscaped && it == '\\') {
+                characterEscaped = true
             } else {
                 stringBuilder.append(it)
                 characterEscaped = false


### PR DESCRIPTION
Attempts to escape strings while parsing arguments. Should fix stuff like this. 
![](https://cdn.discordapp.com/attachments/511324119728521285/812680928496189480/unknown.png) 
[(Original conversation about this issue on fabricord)](https://discord.com/channels/507304429255393322/511324119728521285/812680380976463923)
It also allows you to escape quotation marks with a backslash. I haven't tested this, so maybe test this before releasing.